### PR TITLE
Adds the functionality to allow nested lookups work within iterables.

### DIFF
--- a/lifter/utils.py
+++ b/lifter/utils.py
@@ -10,6 +10,9 @@ class IterableAttr(object):
     def __eq__(self, other):
         return other in self._items
 
+    def __getitem__(self, key):
+        return self.__class__(self._items, key)
+
 
 def attrgetter(*items):
 

--- a/lifter/utils.py
+++ b/lifter/utils.py
@@ -1,6 +1,16 @@
 
 import operator
 
+
+class IterableAttr(object):
+
+    def __init__(self, iterable, key):
+        self._items = [item[key] for item in iterable]
+
+    def __eq__(self, other):
+        return other in self._items
+
+
 def attrgetter(*items):
 
     if any(not isinstance(item, str) for item in items):
@@ -21,9 +31,13 @@ def resolve_attr(obj, attr):
         try:
             obj = getattr(obj, name)
         except AttributeError:
-            obj = obj[name]
-        except KeyError:
-            raise ValueError('Object {0} has no attribute or key "{1}"'.format(obj, key))
+            try:
+                try:
+                    obj = obj[name]
+                except TypeError:
+                    obj = IterableAttr(obj, name)
+            except (KeyError, TypeError):
+                raise ValueError('Object {0} has no attribute or key "{1}"'.format(obj, name))
     return obj
 
 def unique_everseen(seq):

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -119,7 +119,7 @@ class TestQueries(TestBase):
             }
         ]
         manager = lifter.load(companies)
-        self.assertNotIn(users[1], manager.filter(employees__tags__name='friendly'))
+        self.assertNotIn(companies[1], manager.filter(employees__tags__name='friendly'))
 
     def test_can_exclude(self):
         self.assertEqual(self.manager.exclude(a=1), self.OBJECTS[2:])

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -93,6 +93,34 @@ class TestQueries(TestBase):
         self.assertNotIn(users[1], manager.filter(tags__name='nice'))
         self.assertRaises(ValueError, manager.filter, tags__x='y')
 
+        companies = [
+            {
+                'name': 'blackbooks',
+                'employees': [
+                    {
+                        'name': 'Manny',
+                        'tags': [
+                            {'name': 'nice'},
+                            {'name': 'friendly'},
+                        ]
+                    }
+                ]
+            },
+            {
+                'name': 'community',
+                'employees': [
+                    {
+                        'name': 'Britta',
+                        'tags': [
+                            {'name': 'activist'},
+                        ]
+                    }
+                ]
+            }
+        ]
+        manager = lifter.load(companies)
+        self.assertNotIn(users[1], manager.filter(employees__tags__name='friendly'))
+
     def test_can_exclude(self):
         self.assertEqual(self.manager.exclude(a=1), self.OBJECTS[2:])
 

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -69,6 +69,30 @@ class TestQueries(TestBase):
         self.assertEqual(self.dict_manager.exclude(parent__name='parent_1'), self.DICTS[2:])
         self.assertEqual(self.dict_manager.get(parent__name='parent_1', order=2), self.DICTS[0])
 
+    def test_exception_raised_on_missing_attr(self):
+        self.assertRaises(ValueError, self.manager.filter, x="y")
+        self.assertRaises(ValueError, self.dict_manager.filter, x="y")
+
+    def test_can_check_nested_iterables(self):
+        users = [
+            {
+                'name': 'Kurt',
+                'tags': [
+                    {'name': 'nice'},
+                    {'name': 'friendly'},
+                ]
+            },
+            {
+                'name': 'Bill',
+                'tags': [
+                    {'name': 'friendly'},
+                ]
+            },
+        ]
+        manager = lifter.load(users)
+        self.assertNotIn(users[1], manager.filter(tags__name='nice'))
+        self.assertRaises(ValueError, manager.filter, tags__x='y')
+
     def test_can_exclude(self):
         self.assertEqual(self.manager.exclude(a=1), self.OBJECTS[2:])
 


### PR DESCRIPTION
Added tests from example within issue #3. 

Follows the EAFP pattern used in `resolve_attr`, and creates an object which is used to check whether a value is present in a given iterable.