### PR TITLE
Added a basic implementation of Q objects, see #1

### DIFF
--- a/lifter/__init__.py
+++ b/lifter/__init__.py
@@ -4,7 +4,7 @@ __author__ = 'Eliot Berriot'
 __email__ = 'contact@eliotberriot.com'
 __version__ = '0.1.0'
 
-from .query import Manager, DoesNotExist, MultipleObjectsReturned
+from .query import Manager, DoesNotExist, MultipleObjectsReturned, Q
 from . import lookups
 from .lookups import *
 from .aggregates import *

--- a/lifter/lookups.py
+++ b/lifter/lookups.py
@@ -10,6 +10,10 @@ class OneValueLookup(BaseLookup):
     def __init__(self, value):
         self.reference_value = value
 
+class exact(OneValueLookup):
+    def lookup(self, value):
+        return value == self.reference_value
+        
 class gt(OneValueLookup):
     """Greater than"""
     def lookup(self, value):

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -217,6 +217,66 @@ class TestQueries(TestBase):
         self.assertEqual(self.manager.values_list('a', flat=True).distinct(), [1, 2])
         self.assertEqual(self.manager.values_list('parent', flat=True).distinct(), self.PARENTS)
 
+class TestQObjects(TestBase):
+
+    def test_q_object_can_match_objects(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name='test')
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching))
+
+    def test_q_object_can_match_objects_using_lookup(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name=lifter.startswith('te'))
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching))
+
+    def test_can_invert_q_object(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = ~lifter.Q(name='test')
+
+        self.assertFalse(query.match(matching))
+        self.assertTrue(query.match(not_matching))
+
+    def test_can_combine_q_objects_or(self):
+        matching1 = {'name': 'test'}
+        matching2 = {'name': 'bernard'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name='test') | lifter.Q(name='bernard')
+
+        self.assertTrue(query.match(matching1))
+        self.assertTrue(query.match(matching2))
+        self.assertFalse(query.match(not_matching))
+
+        query = query | lifter.Q(name='manny')
+
+        self.assertTrue(query.match(matching1))
+        self.assertTrue(query.match(matching2))
+        self.assertTrue(query.match(not_matching))
+
+    def test_can_combine_q_objects_and(self):
+        matching = {'name': 'test'}
+        not_matching1 = {'name': 'bernard'}
+        not_matching2 = {'name': 'manny'}
+
+        query = lifter.Q(name=lifter.contains('e')) & lifter.Q(name=lifter.startswith('t'))
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching1))
+        self.assertFalse(query.match(not_matching2))
+
+
+
+
 class TestLookups(TestBase):
     def test_gt(self):
         self.assertEqual(self.manager.filter(order=lifter.lookups.gt(3)), [self.OBJECTS[3]])

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -219,6 +219,10 @@ class TestQueries(TestBase):
 
 class TestQObjects(TestBase):
 
+    def test_q_object_cast_kwargs_to_lookup_if_needed(self):
+        query = lifter.Q(name='test')
+        self.assertTrue(isinstance(query.lookup, lifter.exact))
+
     def test_q_object_can_match_objects(self):
         matching = {'name': 'test'}
         not_matching = {'name': 'manny'}


### PR DESCRIPTION
This is a basic implementation of Q objects. Right now, lifter does not use them in any way, but it should be easy enough to convert `filter`, `exclude` and other queryset arguments to `Q` objects.