### PR TITLE
Better handling of lookups on nested iterables

### DIFF
--- a/lifter/__init__.py
+++ b/lifter/__init__.py
@@ -4,7 +4,7 @@ __author__ = 'Eliot Berriot'
 __email__ = 'contact@eliotberriot.com'
 __version__ = '0.1.0'
 
-from .query import Manager, DoesNotExist, MultipleObjectsReturned
+from .query import Manager, DoesNotExist, MultipleObjectsReturned, Q
 from . import lookups
 from .lookups import *
 from .aggregates import *

--- a/lifter/__init__.py
+++ b/lifter/__init__.py
@@ -8,6 +8,7 @@ from .query import Manager, DoesNotExist, MultipleObjectsReturned, Q
 from . import lookups
 from .lookups import *
 from .aggregates import *
+from . import utils
 
 def load(values):
     return Manager(values)

--- a/lifter/lookups.py
+++ b/lifter/lookups.py
@@ -10,6 +10,10 @@ class OneValueLookup(BaseLookup):
     def __init__(self, value):
         self.reference_value = value
 
+class exact(OneValueLookup):
+    def lookup(self, value):
+        return value == self.reference_value
+        
 class gt(OneValueLookup):
     """Greater than"""
     def lookup(self, value):

--- a/lifter/lookups.py
+++ b/lifter/lookups.py
@@ -1,3 +1,4 @@
+from . import utils
 
 class BaseLookup(object):
     def __call__(self, value):
@@ -13,7 +14,7 @@ class OneValueLookup(BaseLookup):
 class exact(OneValueLookup):
     def lookup(self, value):
         return value == self.reference_value
-        
+
 class gt(OneValueLookup):
     """Greater than"""
     def lookup(self, value):

--- a/lifter/query.py
+++ b/lifter/query.py
@@ -46,7 +46,15 @@ class Q(object):
             do_match = self.operator_matcher([child.match(obj) for child in self.children])
         else:
             getter = utils.attrgetter(self.field)
-            do_match = self.lookup(getter(obj))
+            value = getter(obj)
+            if not isinstance(value, utils.IterableAttr):
+                do_match = self.lookup(value)
+            else:
+                if utils.need_flattening(value):
+                    values = utils.flatten(value)
+                else:
+                    values = value
+                do_match = any([self.lookup(item) for item in values])
 
         if self.negated:
             return not do_match

--- a/lifter/utils.py
+++ b/lifter/utils.py
@@ -1,14 +1,42 @@
 
 import operator
 
+def need_flattening(value):
+    try:
+        return isinstance(value[0], IterableAttr)
+    except (IndexError, TypeError):
+        return False
+
+def flatten(root):
+    """Resolve of attributes into a flat list so we can run a lookup against each of these values"""
+    if isinstance(root, IterableAttr):
+        for value in root._items:
+            if need_flattening(value):
+                for subvalue in flatten(value):
+                    yield subvalue
+            else:
+                yield value
+
+    else:
+        yield root
+
+
 
 class IterableAttr(object):
 
     def __init__(self, iterable, key):
+        self._key = key
         self._items = [item[key] for item in iterable]
 
-    def __eq__(self, other):
-        return other in self._items
+    def __repr__(self):
+        REPR_OUTPUT_SIZE = 10
+        data = list(self._items[:REPR_OUTPUT_SIZE + 1])
+        if len(data) > REPR_OUTPUT_SIZE:
+            data[-1] = "...(remaining elements truncated)..."
+        return '<IterableAttr %r>' % data
+
+    def __len__(self):
+        return len(self._items)
 
     def __getitem__(self, key):
         return self.__class__(self._items, key)

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -217,6 +217,66 @@ class TestQueries(TestBase):
         self.assertEqual(self.manager.values_list('a', flat=True).distinct(), [1, 2])
         self.assertEqual(self.manager.values_list('parent', flat=True).distinct(), self.PARENTS)
 
+class TestQObjects(TestBase):
+
+    def test_q_object_can_match_objects(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name='test')
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching))
+
+    def test_q_object_can_match_objects_using_lookup(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name=lifter.startswith('te'))
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching))
+
+    def test_can_invert_q_object(self):
+        matching = {'name': 'test'}
+        not_matching = {'name': 'manny'}
+
+        query = ~lifter.Q(name='test')
+
+        self.assertFalse(query.match(matching))
+        self.assertTrue(query.match(not_matching))
+
+    def test_can_combine_q_objects_or(self):
+        matching1 = {'name': 'test'}
+        matching2 = {'name': 'bernard'}
+        not_matching = {'name': 'manny'}
+
+        query = lifter.Q(name='test') | lifter.Q(name='bernard')
+
+        self.assertTrue(query.match(matching1))
+        self.assertTrue(query.match(matching2))
+        self.assertFalse(query.match(not_matching))
+
+        query = query | lifter.Q(name='manny')
+
+        self.assertTrue(query.match(matching1))
+        self.assertTrue(query.match(matching2))
+        self.assertTrue(query.match(not_matching))
+
+    def test_can_combine_q_objects_and(self):
+        matching = {'name': 'test'}
+        not_matching1 = {'name': 'bernard'}
+        not_matching2 = {'name': 'manny'}
+
+        query = lifter.Q(name=lifter.contains('e')) & lifter.Q(name=lifter.startswith('t'))
+
+        self.assertTrue(query.match(matching))
+        self.assertFalse(query.match(not_matching1))
+        self.assertFalse(query.match(not_matching2))
+
+
+
+
 class TestLookups(TestBase):
     def test_gt(self):
         self.assertEqual(self.manager.filter(order=lifter.lookups.gt(3)), [self.OBJECTS[3]])

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -219,6 +219,10 @@ class TestQueries(TestBase):
 
 class TestQObjects(TestBase):
 
+    def test_q_object_cast_kwargs_to_lookup_if_needed(self):
+        query = lifter.Q(name='test')
+        self.assertTrue(isinstance(query.lookup, lifter.exact))
+
     def test_q_object_can_match_objects(self):
         matching = {'name': 'test'}
         not_matching = {'name': 'manny'}

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -134,6 +134,7 @@ class TestQueries(TestBase):
         self.assertEqual([companies[0]], manager.filter(employees__tags__name='friendly'))
         self.assertEqual([companies[0]], manager.filter(employees__tags__name=lifter.startswith('fr')))
         self.assertEqual([companies[1], companies[2]], manager.filter(employees__tags__name=lifter.icontains('act')))
+        self.assertEqual([companies[1], companies[2]], manager.filter(employees__tags={'name': 'activist'}))
 
     def test_can_exclude(self):
         self.assertEqual(self.manager.exclude(a=1), self.OBJECTS[2:])

--- a/tests/test_lifter.py
+++ b/tests/test_lifter.py
@@ -90,7 +90,7 @@ class TestQueries(TestBase):
             },
         ]
         manager = lifter.load(users)
-        self.assertNotIn(users[1], manager.filter(tags__name='nice'))
+        self.assertEqual([users[0]], manager.filter(tags__name='nice'))
         self.assertRaises(ValueError, manager.filter, tags__x='y')
 
         companies = [
@@ -116,10 +116,24 @@ class TestQueries(TestBase):
                         ]
                     }
                 ]
-            }
+            },
+            {
+                'name': 'narcos',
+                'employees': [
+                    {
+                        'name': 'pablo escobar',
+                        'tags': [
+                            {'name': 'drug dealer'},
+                            {'name': 'activist'},
+                        ]
+                    }
+                ]
+            },
         ]
         manager = lifter.load(companies)
-        self.assertNotIn(companies[1], manager.filter(employees__tags__name='friendly'))
+        self.assertEqual([companies[0]], manager.filter(employees__tags__name='friendly'))
+        self.assertEqual([companies[0]], manager.filter(employees__tags__name=lifter.startswith('fr')))
+        self.assertEqual([companies[1], companies[2]], manager.filter(employees__tags__name=lifter.icontains('act')))
 
     def test_can_exclude(self):
         self.assertEqual(self.manager.exclude(a=1), self.OBJECTS[2:])


### PR DESCRIPTION
Okay, I spend a few hours working on this and I have to say my brain is burning. There is a real complexity when working on nested iterable, mostly because there is a lot of edge cases to handle. 

Thanks to `Q` objects, and the work @Ogreman already done on iterables, I've managed to build a simple implementation that does the work, but when I try to handle all the cases, everything becomes an incredible mess.

Right now, the tests pass on a few complex lookups, so I'm pretty confident it will work on all:

```python
self.assertEqual([companies[0]], manager.filter(employees__tags__name='friendly'))
self.assertEqual([companies[0]], manager.filter(employees__tags__name=lifter.startswith('fr')))
self.assertEqual([companies[1], companies[2]], manager.filter(employees__tags__name=lifter.icontains('act')))
```
All previous example pass, you can find them in the test suite.

But, when you try to match on an iterable element exactly (not on an iterable element attribute), everything the queryset just return empty:

```python
self.assertEqual([companies[1], companies[2]], manager.filter(employees__tags={'name': 'activist'}))
```

Internally, it seems `IterableAttr` stores things in nested list in some situations, which cause exact lookup on iterable to fail. All my attempts to flatten them broke everything.

@Ogreman: if you have an idea to solve this last case, it would be great because the recursion just gave me a headache :p





