### PR TITLE
Can now query for field existences, fix #26

### DIFF
--- a/lifter/exceptions.py
+++ b/lifter/exceptions.py
@@ -5,3 +5,6 @@ class DoesNotExist(ValueError):
 
 class MultipleObjectsReturned(ValueError):
     pass
+
+class MissingAttribute(AttributeError):
+    pass

--- a/lifter/exceptions.py
+++ b/lifter/exceptions.py
@@ -1,10 +1,15 @@
 
-class DoesNotExist(ValueError):
+class LifterException(Exception):
     pass
 
 
-class MultipleObjectsReturned(ValueError):
+class DoesNotExist(LifterException, ValueError):
     pass
 
-class MissingAttribute(AttributeError):
+
+class MultipleObjectsReturned(LifterException, ValueError):
+    pass
+
+
+class MissingAttribute(LifterException, ValueError):
     pass

--- a/lifter/query.py
+++ b/lifter/query.py
@@ -59,6 +59,9 @@ class Path(object):
     def test(self, func):
         return self._query.test(func)
 
+    def exists(self):
+        return self._query.exists()
+
 class Aggregation(object):
     def __init__(self, path, func):
         self.path = path
@@ -158,6 +161,16 @@ class Query(object):
         return self._generate_test(
             func, ('test', self.path, func)
         )
+
+    def exists(self):
+        def impl(value):
+            try:
+                v = self.path.get(value)
+                return True
+            except (AttributeError, KeyError):
+                return False
+
+        return QueryImpl(impl, ('exists', self.path))
 
     # __contains__, matches, search, any, all, exists probably
 

--- a/lifter/query.py
+++ b/lifter/query.py
@@ -167,7 +167,7 @@ class Query(object):
             try:
                 v = self.path.get(value)
                 return True
-            except (AttributeError, KeyError):
+            except exceptions.MissingAttribute:
                 return False
 
         return QueryImpl(impl, ('exists', self.path))

--- a/lifter/utils.py
+++ b/lifter/utils.py
@@ -1,5 +1,6 @@
 
 import operator
+from . import exceptions
 
 
 class IterableAttr(object):
@@ -40,7 +41,7 @@ def resolve_attr(obj, attr):
                 except TypeError:
                     obj = IterableAttr(obj, name)
             except (KeyError, TypeError):
-                raise ValueError('Object {0} has no attribute or key "{1}"'.format(obj, name))
+                raise exceptions.MissingAttribute('Object {0} has no attribute or key "{1}"'.format(obj, name))
     return obj
 
 def unique_everseen(seq):

--- a/tests/test_explicit_query_engine.py
+++ b/tests/test_explicit_query_engine.py
@@ -117,9 +117,9 @@ class TestQueries(TestBase):
 
 
     def test_exception_raised_on_missing_attr(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(lifter.exceptions.MissingAttribute):
             list(self.manager.filter(TestModel.x == "y"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(lifter.exceptions.MissingAttribute):
             list(self.dict_manager.filter(TestModel.x == "y"))
 
     def test_can_count(self):
@@ -317,6 +317,24 @@ class TestLookups(TestBase):
     def test_icontains(self):
         self.assertEqual(self.manager.filter(TestModel.surname.test(lifter.icontains('lin'))),
                         [self.OBJECTS[2], self.OBJECTS[3]])
+
+    def test_field_exists(self):
+
+        families = [
+            {
+                'name': 'Community',
+                'postal_adress': 'Greendale',
+            },
+            {
+                'name': 'Misfits',
+            }
+        ]
+
+        Family = lifter.models.Model('Family')
+        manager = Family.load(families)
+
+        self.assertEqual(manager.filter(Family.postal_adress.exists()), [families[0]])
+        self.assertEqual(manager.filter(~Family.postal_adress.exists()), [families[1]])
 
 def mean(values):
     return float(sum(values)) / len(values)

--- a/tests/test_keyword_engine.py
+++ b/tests/test_keyword_engine.py
@@ -72,9 +72,9 @@ class TestQueries(TestBase):
         self.assertEqual(self.dict_manager.get(parent__name='parent_1', order=2), self.DICTS[0])
 
     def test_exception_raised_on_missing_attr(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(lifter.exceptions.MissingAttribute):
             self.manager.filter(x="y").count()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(lifter.exceptions.MissingAttribute):
             self.dict_manager.filter(x="y").count()
 
     # def test_can_check_nested_iterables(self):


### PR DESCRIPTION
The API is as follow.

Filter objects with the field:

```python
manager.filter(Model.optional_field.exists())
```

Filter objects without the field:

```python
manager.filter(~Model.optional_field.exists())
```